### PR TITLE
Bump Stack version to LTS 7.1

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-6.3
+resolver: lts-7.1
 packages:
 - '.'


### PR DESCRIPTION
After cloning the repo, I got the following error before bumping to the latest
LTS:

```
uio-imac-03:cassava-megaparsec justin$ stack build
Populated index cache.
While constructing the BuildPlan the following exceptions were encountered:

--  Failure when adding dependencies:
      megaparsec: needed (>=5.0 && <6.0), 4.4.0 found (latest applicable is 5.0.1)
    needed for package cassava-megaparsec-0.1.0
```

Bumping the Stack LTS to the latest version fixed the error for me.