### PR TITLE
[Issue 4] Incremental parsing for CSV with Headers

### DIFF
--- a/Data/Csv/Parser/Megaparsec/Incremental.hs
+++ b/Data/Csv/Parser/Megaparsec/Incremental.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Data.Csv.Parser.Megaparsec.Incremental (decodeHeader) where
+
+import           Data.ByteString                      (ByteString)
+import           Data.ByteString.Lazy                 (fromStrict)
+import           Data.Csv                             (FromNamedRecord,
+                                                       defaultDecodeOptions)
+import           Data.Csv.Incremental                 hiding (decodeHeader)
+import           Data.Csv.Parser.Megaparsec.Internals (csvWithHeader)
+import qualified Data.Vector                          as V
+import           Text.Megaparsec                      (errorBundlePretty, parse)
+
+
+-- | TODO: Add something here
+decodeHeader :: FromNamedRecord a => HeaderParser (V.Vector a)
+decodeHeader = PartialH (\bs ->
+    case parser (fromStrict bs) of
+      (Left parseError) -> FailH mempty (errorBundlePretty parseError)
+      (Right (h, r))    -> DoneH h r
+  )
+  where
+    parser = parse (csvWithHeader defaultDecodeOptions) ""

--- a/cassava-megaparsec.cabal
+++ b/cassava-megaparsec.cabal
@@ -57,6 +57,7 @@ test-suite tests
                     , hspec              >= 2.0  && < 3.0
                     , hspec-megaparsec   >= 2.0  && < 3.0
                     , vector             >= 0.11 && < 0.13
+  other-modules:      IncrementalSpec
   if flag(dev)
     ghc-options:      -Wall -Werror
   else

--- a/cassava-megaparsec.cabal
+++ b/cassava-megaparsec.cabal
@@ -33,6 +33,7 @@ library
                     , vector           >= 0.11  && < 0.13
   exposed-modules:    Data.Csv.Parser.Megaparsec
                     , Data.Csv.Parser.Megaparsec.Internals
+                    , Data.Csv.Parser.Megaparsec.Incremental
   if flag(dev)
     ghc-options:      -Wall -Werror
   else

--- a/tests/IncrementalSpec.hs
+++ b/tests/IncrementalSpec.hs
@@ -1,48 +1,74 @@
 {-# LANGUAGE BangPatterns  #-}
 {-# LANGUAGE DeriveGeneric #-}
 
-module IncrementalSpec (spec) where
+module IncrementalSpec  where
 
+import           Data.ByteString                        (ByteString)
 import           Data.ByteString.Char8                  (pack)
 import           Data.Csv                               hiding (NamedRecord)
 import           Data.Csv.Incremental                   (HeaderParser (..))
 import           Data.Csv.Parser.Megaparsec.Incremental
-import           Data.Vector                            (Vector)
+import           Data.List                              (isInfixOf, uncons)
+import qualified Data.Vector                            as V
 import qualified Debug.Trace                            as DT
 import           GHC.Generics
-import           GHC.List                               (uncons)
 import           Test.Hspec
 
 spec :: Spec
 spec =
   describe "Decoding with headers" decodingHeaderSpec
 
-data Person = Person { name :: String, age :: Int } deriving Generic
+data Person = Person { name :: String, age :: Int } deriving (Show, Generic)
 
 instance FromNamedRecord Person
 
-dataF = unwords
+dataFailure :: String
+dataFailure = unlines
   [ "name,age"
   , "Bart,10"
   , "MrBurns,Unknown"
   , "Lisa,8"
   ]
 
-feed input n f =
-  case nextLine of
-    Just value -> f (pack value)
-    Nothing    -> f mempty
-  where
-    remainingLines = drop n (words input)
-    nextLine = fst <$> uncons remainingLines
-
-goParser !acc input r@(PartialH f) = goParser (acc + 1) input (feed input acc f)
-goParser _ _ r                     = r
+dataSuccess :: String
+dataSuccess = unlines
+  [ "name,age"
+  , "Bart,10"
+  , "Lisa,8"
+  , "Maggie,1"
+  ]
 
 decodingHeaderSpec :: Spec
-decodingHeaderSpec =
+decodingHeaderSpec = do
   describe "given csv with malformed input in the middle" $
-    fit "returns FailH with the uncomsumed input and and error message" $
-      case goParser 0 dataF (decodeHeader :: HeaderParser (Vector Person)) of
-        FailH _ errorMsg -> (DT.traceShowId errorMsg) == ""
+    it "returns FailH with the uncomsumed input and and error message" $
+      case goParser 0 dataFailure (decodeHeader :: HeaderParser (V.Vector Person)) of
+        FailH _ errorMsg -> "got \"Unknown\"" `isInfixOf` errorMsg
         _                -> False
+
+  describe "given csv with all right input" $
+    it "returns DoneH with the comsumed input" $
+      case goParser 0 dataSuccess (decodeHeader :: HeaderParser (V.Vector Person)) of
+        DoneH _ r -> V.length (DT.traceShowId r) == 3
+        _         -> False
+
+-- | Helpers
+
+-- Parses a single line with a header at a time
+feed :: Maybe (String, [String]) -> (ByteString -> a) -> a
+feed input f =
+  case input of
+    Just (firstLine, nextLine:_) -> f (pack $ unlines [firstLine, nextLine])
+    Just (_, [])                 -> f mempty
+    _                            -> f mempty
+
+-- Parses the given string until the end
+goParser :: Int -> String -> HeaderParser a -> HeaderParser a
+goParser !acc input (PartialH f) = goParser (acc + 1) input (feed input' f)
+  where
+    input' =
+      case uncons (lines input) of
+        Just (fl, nls) -> Just (fl, drop acc nls)
+        _              -> Nothing
+goParser _ _ r                   = r
+

--- a/tests/IncrementalSpec.hs
+++ b/tests/IncrementalSpec.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE BangPatterns  #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module IncrementalSpec (spec) where
+
+import           Data.ByteString.Char8                  (pack)
+import           Data.Csv                               hiding (NamedRecord)
+import           Data.Csv.Incremental                   (HeaderParser (..))
+import           Data.Csv.Parser.Megaparsec.Incremental
+import           Data.Vector                            (Vector)
+import qualified Debug.Trace                            as DT
+import           GHC.Generics
+import           GHC.List                               (uncons)
+import           Test.Hspec
+
+spec :: Spec
+spec =
+  describe "Decoding with headers" decodingHeaderSpec
+
+data Person = Person { name :: String, age :: Int } deriving Generic
+
+instance FromNamedRecord Person
+
+dataF = unwords
+  [ "name,age"
+  , "Bart,10"
+  , "MrBurns,Unknown"
+  , "Lisa,8"
+  ]
+
+feed input n f =
+  case nextLine of
+    Just value -> f (pack value)
+    Nothing    -> f mempty
+  where
+    remainingLines = drop n (words input)
+    nextLine = fst <$> uncons remainingLines
+
+goParser !acc input r@(PartialH f) = goParser (acc + 1) input (feed input acc f)
+goParser _ _ r                     = r
+
+decodingHeaderSpec :: Spec
+decodingHeaderSpec =
+  describe "given csv with malformed input in the middle" $
+    fit "returns FailH with the uncomsumed input and and error message" $
+      case goParser 0 dataF (decodeHeader :: HeaderParser (Vector Person)) of
+        FailH _ errorMsg -> (DT.traceShowId errorMsg) == ""
+        _                -> False

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -3,17 +3,19 @@
 
 module Main (main) where
 
-import Data.ByteString (ByteString)
-import Data.Csv hiding (decode, decodeWith, decodeByName, decodeByNameWith)
-import Data.Csv.Parser.Megaparsec
-import Data.Vector (Vector)
-import Test.Hspec
-import Test.Hspec.Megaparsec
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.Vector          as V
+import           Data.ByteString            (ByteString)
+import qualified Data.ByteString.Lazy       as BL
+import           Data.Csv                   hiding (decode, decodeByName,
+                                             decodeByNameWith, decodeWith)
+import           Data.Csv.Parser.Megaparsec
+import           Data.Vector                (Vector)
+import qualified Data.Vector                as V
+import qualified IncrementalSpec
+import           Test.Hspec
+import           Test.Hspec.Megaparsec
 
 #if !MIN_VERSION_base(4,8,0)
-import Control.Applicative ((<$>))
+import           Control.Applicative        ((<$>))
 #endif
 
 main :: IO ()
@@ -25,6 +27,7 @@ spec = do
   describe "decodeWith"       decodeWithSpec
   describe "decodeByName"     decodeByNameSpec
   describe "decodeByNameWith" decodeByNameWithSpec
+  describe "Incremental"      IncrementalSpec.spec
 
 decodeSpec :: Spec
 decodeSpec = do


### PR DESCRIPTION
It solves part of #4. I'll add the changes 'incrementally' (pun intended).

## Changes:
- Add new module Data.Csv.Parser.Megaparsec.Incremental
- Expose `decodeHeader`
- Add tests for it


## TODO:
- [ ] Fix TODO
- [ ] Document code
- [ ] Address some edge cases
