### PR TITLE
chore(ci): fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           SDIST_PATH=$(ls dist-newstyle/sdist/cassava-megaparsec-*.tar.gz)
           curl -X POST \
-	   -- fail -i \
+	   --fail -i \
            -H 'Accept: text/plain' \
            -H "Authorization: X-ApiKey ${HACKAGE_API_KEY}" \
            --form "package=@${SDIST_PATH}" \
@@ -50,8 +50,9 @@ jobs:
           TAG_VERSION=${{ github.ref_name }}
           DOCS_PATH=$(ls dist-newstyle/cassava-megaparsec-*-docs.tar.gz)
           curl -X PUT \
+	   --fail -i \
            -H 'Content-Type: application/x-tar' \
            -H 'Content-Encoding: gzip' \
-           -H "Authorization: X-ApiKey \"$HACKAGE_API_KEY\"" \
+           -H "Authorization: X-ApiKey ${HACKAGE_API_KEY}" \
            --data-binary "@${DOCS_PATH}" \
            "https://hackage.haskell.org/package/cassava-megaparsec-$TAG_VERSION/candidate/docs"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,8 +35,9 @@ jobs:
         run: |
           SDIST_PATH=$(ls dist-newstyle/sdist/cassava-megaparsec-*.tar.gz)
           curl -X POST \
+	   -- fail -i \
            -H 'Accept: text/plain' \
-           -H "Authorization: X-ApiKey \"$HACKAGE_API_KEY\"" \
+           -H "Authorization: X-ApiKey ${HACKAGE_API_KEY}" \
            --form "package=@${SDIST_PATH}" \
            "https://hackage.haskell.org/packages/candidates"
       - name: Generate documentation


### PR DESCRIPTION
The string interpolation for the Hackage API key is not implemented correctly.