### PR TITLE
misc: change tabs to spaces

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,16 @@
----
 name: Release
-
 on:
   release:
     types:
       - published
-
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   hackage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
       - name: Setup Haskell
         id: setup-haskell-cabal
         uses: haskell/actions/setup@v2
@@ -25,32 +20,29 @@ jobs:
           # - https://github.com/haskell/cabal/issues/8326
           ghc-version: "8.10.7"
           cabal-version: "3.6"
-
       - name: Generate sdist
         run: cabal sdist
-
       - name: Upload candidate package to Hackage
         env:
           HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
         run: |
           SDIST_PATH=$(ls dist-newstyle/sdist/cassava-megaparsec-*.tar.gz)
           curl -X POST \
-	   --fail -i \
+           --fail -i \
            -H 'Accept: text/plain' \
            -H "Authorization: X-ApiKey ${HACKAGE_API_KEY}" \
            --form "package=@${SDIST_PATH}" \
            "https://hackage.haskell.org/packages/candidates"
       - name: Generate documentation
         run: cabal haddock --haddock-for-hackage --enable-documentation
-
       - name: Upload Docs for candidate to Hackage
         env:
           HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
-        run: |
+        run: |-
           TAG_VERSION=${{ github.ref_name }}
           DOCS_PATH=$(ls dist-newstyle/cassava-megaparsec-*-docs.tar.gz)
           curl -X PUT \
-	   --fail -i \
+           --fail -i \
            -H 'Content-Type: application/x-tar' \
            -H 'Content-Encoding: gzip' \
            -H "Authorization: X-ApiKey ${HACKAGE_API_KEY}" \


### PR DESCRIPTION
The previous fix of the publish workflow introduced tabs to the .yml file. I have remove them and run yamlfmt to make sure it is correctly formatted.