### PR TITLE
chore: include 9.6 and 9.8 to GHC matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ['8.2', '8.4', '8.6', '8.8', '8.10', '9.0', '9.2', '9.4']
+        ghc: ['8.2', '8.4', '8.6', '8.8', '8.10', '9.0', '9.2', '9.4', '9.6', '9.8']
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Haskell tooling
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: "3.6"

--- a/cassava-megaparsec.cabal
+++ b/cassava-megaparsec.cabal
@@ -2,6 +2,8 @@ cabal-version:        2.0
 name:                 cassava-megaparsec
 version:              2.1.0
 tested-with:
+  GHC==9.8.1
+  GHC==9.6.3
   GHC==9.4.4
   GHC==9.2.5
   GHC==9.0.2


### PR DESCRIPTION
- Adds GHC 9.6 and 9.8 to build matrix
- Updates Haskell action source see https://github.com/haskell/actions?tab=readme-ov-file
- Updates tested-with in .cabal file