### PR TITLE
Added `kleidukos/get-tested action` to generate CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  haskell:
+  generate-matrix:
+    name: "Generate matrix from cabal"
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ghc: ['8.2', '8.4', '8.6', '8.8', '8.10', '9.0', '9.2', '9.4', '9.6', '9.8']
+    steps:
+      - name: Extract the tested GHC versions
+        id: set-matrix
+        uses: kleidukos/get-tested@v0.1.7.0
+        with:
+          cabal-file: get-tested.cabal
+          ubuntu-version: latest
+          version: 0.1.7.0
 
+  build-and-test:
+    name: ${{ matrix.ghc }} on ${{ matrix.os }}
+    needs: generate-matrix
+    strategy:
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         id: set-matrix
         uses: kleidukos/get-tested@v0.1.7.0
         with:
-          cabal-file: get-tested.cabal
+          cabal-file: cassava-megaparsec.cabal
           ubuntu-version: latest
           version: 0.1.7.0
 


### PR DESCRIPTION
Thanks to the [get-tested](https://github.com/Kleidukos/get-tested) action, we can automatically generate the matrix of GHC versions to run the CI on. This keeps the `tested-with` versions we set in Cabal files accurate to what is actually being tested in the CI.